### PR TITLE
Add FastAPI proxy service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# ollama-proxy
+# Ollama Proxy
+
+This project provides a small FastAPI service that exposes an OpenAI-compatible API on top of [Ollama](https://github.com/jmorganca/ollama). It forwards requests to an Ollama server so that clients written for the OpenAI API can interact with local models.
+
+## Features
+
+- `/v1/models` lists available Ollama models.
+- `/v1/chat/completions` proxies chat completion requests using the same payload structure as the OpenAI API.
+- Supports tool usage (`tools` and `tool_choice`) when forwarding to Ollama.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run an Ollama server locally or set `OLLAMA_BASE_URL` to point to a remote instance.
+3. Start the proxy:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+The service will then be accessible at `http://localhost:8000` and can be used with libraries expecting the OpenAI API. Set `OLLAMA_BASE_URL` to change the upstream Ollama URL.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,73 @@
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+import httpx
+import os
+
+app = FastAPI(title="Ollama Proxy", description="OpenAI compatible API for Ollama models")
+
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+
+
+@app.on_event("startup")
+async def startup_event():
+    app.state.client = httpx.AsyncClient(base_url=OLLAMA_BASE_URL, timeout=None)
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    await app.state.client.aclose()
+
+@app.get("/")
+async def root():
+    return {"message": "Ollama proxy running"}
+
+@app.get("/v1/models")
+async def list_models():
+    """Return available models from Ollama"""
+    try:
+        resp = await app.state.client.get("/api/tags")
+        resp.raise_for_status()
+        data = resp.json()
+        models = [{"id": m["name"], "object": "model"} for m in data.get("models", [])]
+        return {"object": "list", "data": models}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request):
+    """Proxy OpenAI chat completions to Ollama"""
+    body = await request.json()
+    model = body.get("model")
+    messages = body.get("messages")
+    stream = body.get("stream", False)
+    if not model or not messages:
+        raise HTTPException(status_code=400, detail="model and messages required")
+
+    payload = {
+        "model": model,
+        "messages": messages,
+        "stream": stream,
+    }
+    # Add other fields if present
+    for key in ["format", "options", "tools", "tool_choice"]:
+        if key in body:
+            payload[key] = body[key]
+
+    try:
+        resp = await app.state.client.post("/api/chat", json=payload)
+        resp.raise_for_status()
+        if stream:
+            async def iterator():
+                async for chunk in resp.aiter_text():
+                    yield chunk
+            return StreamingResponse(iterator(), media_type="text/event-stream")
+        return JSONResponse(resp.json())
+    except httpx.HTTPError as e:
+        detail = getattr(e, "response", None)
+        if detail is not None:
+            try:
+                err = detail.json()
+            except Exception:
+                err = detail.text
+            raise HTTPException(status_code=detail.status_code, detail=err)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+httpx
+pydantic


### PR DESCRIPTION
## Summary
- implement simple Ollama FastAPI proxy in `app/main.py`
- document usage in `README.md`
- add requirements file for FastAPI server
- refine proxy client setup with startup/shutdown events and env var

## Testing
- `bash check_tools.sh` *(fails: No arguments provided and config file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844827efed88327b1a49d42bec568e2